### PR TITLE
Rename

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET 5.0
 
 env:
   PRERELEASE_BRANCHES: experimental,alpha,beta,rc
-  DOCKER_HUB_REPO: ${{ secrets.RAAEDGE_LOGIN_SERVER }}/modbus
+  DOCKER_HUB_REPO: ${{ secrets.RAAEDGE_LOGIN_SERVER }}/connectors-modbus
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Connectors.Modbus
 
 [![.NET 5.0](https://github.com/RaaLabs/Modbus/actions/workflows/dotnet.yml/badge.svg)](https://github.com/RaaLabs/Modbus/actions/workflows/dotnet.yml)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=RaaLabs_Modbus&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=RaaLabs_Modbus)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=RaaLabs_Modbus&metric=coverage)](https://sonarcloud.io/dashboard?id=RaaLabs_Modbus)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=RaaLabs_Connectors.Modbus&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=RaaLabs_Connectors.Modbus)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=RaaLabs_Connectors.Modbus&metric=coverage)](https://sonarcloud.io/dashboard?id=RaaLabs_Connectors.Modbus)
 
 ## What does it do?
 

--- a/Source/.dockerignore
+++ b/Source/.dockerignore
@@ -1,5 +1,0 @@
-bin
-obj
-out
-data
-Properties

--- a/Source/Bridge/IMaster.cs
+++ b/Source/Bridge/IMaster.cs
@@ -1,7 +1,6 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Threading.Tasks;
 using RaaLabs.Edge.Connectors.Modbus.Model;
 

--- a/Source/Bridge/Master.cs
+++ b/Source/Bridge/Master.cs
@@ -1,7 +1,6 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Net.Sockets;
 using System.Threading.Tasks;

--- a/Source/Bridge/ModbusBridge.cs
+++ b/Source/Bridge/ModbusBridge.cs
@@ -1,3 +1,6 @@
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Source/ByteExtensions.cs
+++ b/Source/ByteExtensions.cs
@@ -1,7 +1,6 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Source/ConnectorConfiguration.cs
+++ b/Source/ConnectorConfiguration.cs
@@ -1,7 +1,6 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using RaaLabs.Edge.Modules.Configuration;
 using RaaLabs.Edge.Connectors.Modbus.Bridge;
 using RaaLabs.Edge.Connectors.Modbus.Model;

--- a/Source/EndiannessExtensions.cs
+++ b/Source/EndiannessExtensions.cs
@@ -1,7 +1,5 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using RaaLabs.Edge.Connectors.Modbus.Model;

--- a/Source/Modbus.csproj
+++ b/Source/Modbus.csproj
@@ -13,9 +13,9 @@
     
     <ItemGroup>
         <PackageReference Include="nmodbus" Version="3.0.62" />
-        <PackageReference Include="RaaLabs.Edge" Version="1.2.3" />
-        <PackageReference Include="RaaLabs.Edge.Modules.Configuration" Version="1.2.3" />
-        <PackageReference Include="RaaLabs.Edge.Modules.EdgeHub" Version="1.2.3" />
-        <PackageReference Include="RaaLabs.Edge.Modules.EventHandling" Version="1.2.3" />
+        <PackageReference Include="RaaLabs.Edge" Version="1.3.1" />
+        <PackageReference Include="RaaLabs.Edge.Modules.Configuration" Version="1.3.1" />
+        <PackageReference Include="RaaLabs.Edge.Modules.EdgeHub" Version="1.3.1" />
+        <PackageReference Include="RaaLabs.Edge.Modules.EventHandling" Version="1.3.1" />
     </ItemGroup>
 </Project>

--- a/Source/ModbusRegisterReceivedHandler.cs
+++ b/Source/ModbusRegisterReceivedHandler.cs
@@ -1,3 +1,6 @@
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using RaaLabs.Edge.Connectors.Modbus.Events;
 using RaaLabs.Edge.Modules.EventHandling;
 using System;

--- a/Source/Model/DataType.cs
+++ b/Source/Model/DataType.cs
@@ -1,7 +1,5 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace RaaLabs.Edge.Connectors.Modbus.Model
 {

--- a/Source/Model/Endianness.cs
+++ b/Source/Model/Endianness.cs
@@ -1,7 +1,5 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace RaaLabs.Edge.Connectors.Modbus.Model
 {

--- a/Source/Model/FunctionCode.cs
+++ b/Source/Model/FunctionCode.cs
@@ -1,7 +1,5 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace RaaLabs.Edge.Connectors.Modbus.Model
 {

--- a/Source/Model/Protocol.cs
+++ b/Source/Model/Protocol.cs
@@ -1,7 +1,5 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace RaaLabs.Edge.Connectors.Modbus.Model
 {

--- a/Source/Model/Register.cs
+++ b/Source/Model/Register.cs
@@ -1,7 +1,5 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
 

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -1,7 +1,6 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using RaaLabs.Edge;
 using RaaLabs.Edge.Modules.EventHandling;
 using RaaLabs.Edge.Modules.Configuration;

--- a/Source/RegistersConfiguration.cs
+++ b/Source/RegistersConfiguration.cs
@@ -1,7 +1,6 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) RaaLabs. All rights reserved.
- *  Licensed under the MIT License. See LICENSE in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using RaaLabs.Edge.Modules.Configuration;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/Specifications/Modbus.Specs.csproj
+++ b/Specifications/Modbus.Specs.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
         <PackageReference Include="Moq" Version="4.16.1" />
-        <PackageReference Include="RaaLabs.Edge.Testing" Version="1.2.3" />
+        <PackageReference Include="RaaLabs.Edge.Testing" Version="1.3.1" />
         <PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="3.8.35" />
         <PackageReference Include="SpecFlow.MsTest" Version="3.8.7" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />


### PR DESCRIPTION
## Summary

### Changed

- Name of docker image from: modbus  to: connectors-modbus

### Fixed

- Copyright in headers
- Newest RaaLabs.Edge nuget

### Removed

- Duplicated dockerignore

