### PR TITLE
RestartOnChange added to the registers.json file

### DIFF
--- a/Source/RegistersConfiguration.cs
+++ b/Source/RegistersConfiguration.cs
@@ -14,6 +14,7 @@ namespace RaaLabs.Edge.Connectors.Modbus
     /// </summary>
     [Name("registers.json")]
     [ExcludeFromCodeCoverage]
+    [RestartOnChange]
     public class RegistersConfiguration :
         ReadOnlyCollection<Register>,
         IConfiguration


### PR DESCRIPTION
## Summary

The Modbus connector should be restarted if new tags are added, resulting in a change in the registers.json file. [restartOnChange] is therefore added.